### PR TITLE
Environment 411 for C1 Sample

### DIFF
--- a/software_stm32/platformio.ini
+++ b/software_stm32/platformio.ini
@@ -94,3 +94,19 @@ build_flags =
 	-DHARDWARE_REVISION_C2
 	-DmotDebug
 	-DappDebug
+
+; build environment for C1 hardware revision
+; for STM32F411 - experimental
+; development version
+[env:STM32F411_development_C1]
+board = blackpill_f411ce
+; change microcontroller
+board_build.mcu = stm32f411ceu6
+; change MCU frequency
+board_build.f_cpu = 100000000L
+build_flags = 
+	-DFIRMWARE_VERSION=${version.firmware_version_dev}
+	-DHARDWARE_VERSION=${version.hardware_version_C1}
+	-DHARDWARE_REVISION_C1
+	-DmotDebug
+	-DappDebug


### PR DESCRIPTION
Added Environment stm32f411 for C1 Sample for Testing

Stm Update worked after Init install STM Board with STM32 Cubeprogrammer.

After the init Install, the board name and ID was readed correct from the STM Board.

The  {"STM32F411xx",     0x431} are correct. 